### PR TITLE
Rename native currency to SCOL

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-// geth is a command-line client for Ethereum.
+// geth is a command-line client for SCOLCOIN.
 package main
 
 import (
@@ -295,7 +295,7 @@ func prepare(ctx *cli.Context) {
 		log.Info("Starting Geth on Hoodi testnet...")
 
 	case !ctx.IsSet(utils.NetworkIdFlag.Name):
-		log.Info("Starting Geth on Ethereum mainnet...")
+		log.Info("Starting Geth on SCOL mainnet...")
 	}
 	// If we're a full node on mainnet without --cache specified, bump default cache allowance
 	if !ctx.IsSet(utils.CacheFlag.Name) && !ctx.IsSet(utils.NetworkIdFlag.Name) {

--- a/common/units.go
+++ b/common/units.go
@@ -1,0 +1,31 @@
+package common
+
+import "math/big"
+
+var (
+	Wei       = big.NewInt(1)
+	KWei      = new(big.Int).Mul(Wei, big.NewInt(1e3))
+	MWei      = new(big.Int).Mul(KWei, big.NewInt(1e3))
+	GWei      = new(big.Int).Mul(MWei, big.NewInt(1e3))
+	MicroSCOL = new(big.Int).Mul(GWei, big.NewInt(1e3))
+	MilliSCOL = new(big.Int).Mul(MicroSCOL, big.NewInt(1e3))
+	SCOL      = new(big.Int).Mul(MilliSCOL, big.NewInt(1e3))
+	KScol     = new(big.Int).Mul(SCOL, big.NewInt(1e3))
+	MScol     = new(big.Int).Mul(KScol, big.NewInt(1e3))
+	GScol     = new(big.Int).Mul(MScol, big.NewInt(1e3))
+	TScol     = new(big.Int).Mul(GScol, big.NewInt(1e3))
+)
+
+var Units = map[string]*big.Int{
+	"wei":  Wei,
+	"kwei": KWei, "babbage": KWei,
+	"mwei": MWei, "lovelace": MWei,
+	"gwei": GWei, "shannon": GWei,
+	"microscol": MicroSCOL, "micro": MicroSCOL,
+	"milliscol": MilliSCOL, "milli": MilliSCOL,
+	"scol":  SCOL,
+	"kscol": KScol, "grand": KScol,
+	"mscol": MScol,
+	"gscol": GScol,
+	"tscol": TScol,
+}

--- a/params/config.go
+++ b/params/config.go
@@ -159,7 +159,7 @@ var (
 		},
 	}
 	// AllEthashProtocolChanges contains every protocol change (EIPs) introduced
-	// and accepted by the Ethereum core developers into the Ethash consensus.
+	// and accepted by the SCOLCOIN core developers into the Ethash consensus.
 	AllEthashProtocolChanges = &ChainConfig{
 		ChainID:                 big.NewInt(1337),
 		HomesteadBlock:          big.NewInt(0),
@@ -214,7 +214,7 @@ var (
 	}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
-	// and accepted by the Ethereum core developers into the Clique consensus.
+	// and accepted by the SCOLCOIN core developers into the Clique consensus.
 	AllCliqueProtocolChanges = &ChainConfig{
 		ChainID:                 big.NewInt(1337),
 		HomesteadBlock:          big.NewInt(0),
@@ -244,7 +244,7 @@ var (
 	}
 
 	// TestChainConfig contains every protocol change (EIPs) introduced
-	// and accepted by the Ethereum core developers for testing purposes.
+	// and accepted by the SCOLCOIN core developers for testing purposes.
 	TestChainConfig = &ChainConfig{
 		ChainID:                 big.NewInt(1),
 		HomesteadBlock:          big.NewInt(0),
@@ -274,7 +274,7 @@ var (
 	}
 
 	// MergedTestChainConfig contains every protocol change (EIPs) introduced
-	// and accepted by the Ethereum core developers for testing purposes.
+	// and accepted by the SCOLCOIN core developers for testing purposes.
 	MergedTestChainConfig = &ChainConfig{
 		ChainID:                 big.NewInt(1),
 		HomesteadBlock:          big.NewInt(0),
@@ -359,7 +359,7 @@ var (
 		Max:            9,
 		UpdateFraction: 5007716,
 	}
-	// DefaultBlobSchedule is the latest configured blob schedule for Ethereum mainnet.
+	// DefaultBlobSchedule is the latest configured blob schedule for SCOLCOIN mainnet.
 	DefaultBlobSchedule = &BlobScheduleConfig{
 		Cancun: DefaultCancunBlobConfig,
 		Prague: DefaultPragueBlobConfig,

--- a/params/denomination.go
+++ b/params/denomination.go
@@ -16,12 +16,14 @@
 
 package params
 
-// These are the multipliers for ether denominations.
+// These are the multipliers for SCOL denominations.
 // Example: To get the wei value of an amount in 'gwei', use
 //
 //	new(big.Int).Mul(value, big.NewInt(params.GWei))
 const (
-	Wei   = 1
-	GWei  = 1e9
-	Ether = 1e18
+	Wei  = 1
+	GWei = 1e9
+	SCOL = 1e18
+	// Ether is kept as an alias for backwards compatibility.
+	Ether = SCOL
 )


### PR DESCRIPTION
## Summary
- rename Ether units to SCOL
- update chain config comments for SCOLCOIN
- update CLI messaging to reference SCOL mainnet

## Testing
- `go test ./...` (fails: verifying module github.com/google/gofuzz@v1.2.0: Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68b61fe21f9c8322af8e56b4338d48ee