### PR TITLE
docs: replace Ethereum links with Scolcoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@
 Golang execution layer implementation of the Ethereum protocol.
 
 [![API Reference](
-https://pkg.go.dev/badge/github.com/ethereum/go-ethereum
-)](https://pkg.go.dev/github.com/ethereum/go-ethereum?tab=doc)
-[![Go Report Card](https://goreportcard.com/badge/github.com/ethereum/go-ethereum)](https://goreportcard.com/report/github.com/ethereum/go-ethereum)
-[![Travis](https://app.travis-ci.com/ethereum/go-ethereum.svg?branch=master)](https://app.travis-ci.com/github/ethereum/go-ethereum)
+https://scolcoin.com/
+)](https://scolcoin.com/)
+[![Go Report Card](https://scolcoin.com/)](https://scolcoin.com/)
+[![Travis](https://scolcoin.com/)](https://scolcoin.com/)
 [![Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://discord.gg/nthXNEv)
-[![Twitter](https://img.shields.io/twitter/follow/go_ethereum)](https://x.com/go_ethereum)
+[![Twitter](https://scolcoin.com/)](https://scolcoin.com/)
 
 Automated builds are available for stable releases and the unstable master branch. Binary
-archives are published at https://geth.ethereum.org/downloads/.
+archives are published at https://scolcoin.com/
 
 ## Building the source
 
-For prerequisites and detailed build instructions please read the [Installation Instructions](https://geth.ethereum.org/docs/getting-started/installing-geth).
+For prerequisites and detailed build instructions please read the [Installation Instructions](https://scolcoin.com/).
 
 Building `geth` requires both a Go (version 1.23 or later) and a C compiler. You can install
 them using your favourite package manager. Once the dependencies are installed, run
@@ -37,17 +37,17 @@ directory.
 
 |  Command   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | :--------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`geth`** | Our main Ethereum CLI client. It is the entry point into the Ethereum network (main-, test- or private net), capable of running as a full node (default), archive node (retaining all historical state) or a light node (retrieving data live). It can be used by other processes as a gateway into the Ethereum network via JSON RPC endpoints exposed on top of HTTP, WebSocket and/or IPC transports. `geth --help` and the [CLI page](https://geth.ethereum.org/docs/fundamentals/command-line-options) for command line options. |
+| **`geth`** | Our main Ethereum CLI client. It is the entry point into the Ethereum network (main-, test- or private net), capable of running as a full node (default), archive node (retaining all historical state) or a light node (retrieving data live). It can be used by other processes as a gateway into the Ethereum network via JSON RPC endpoints exposed on top of HTTP, WebSocket and/or IPC transports. `geth --help` and the [CLI page](https://scolcoin.com/) for command line options. |
 |   `clef`   | Stand-alone signing tool, which can be used as a backend signer for `geth`.                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 |  `devp2p`  | Utilities to interact with nodes on the networking layer, without running a full blockchain.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-|  `abigen`  | Source code generator to convert Ethereum contract definitions into easy-to-use, compile-time type-safe Go packages. It operates on plain [Ethereum contract ABIs](https://docs.soliditylang.org/en/develop/abi-spec.html) with expanded functionality if the contract bytecode is also available. However, it also accepts Solidity source files, making development much more streamlined. Please see our [Native DApps](https://geth.ethereum.org/docs/developers/dapp-developer/native-bindings) page for details.                                  |
+|  `abigen`  | Source code generator to convert Ethereum contract definitions into easy-to-use, compile-time type-safe Go packages. It operates on plain [Ethereum contract ABIs](https://docs.soliditylang.org/en/develop/abi-spec.html) with expanded functionality if the contract bytecode is also available. However, it also accepts Solidity source files, making development much more streamlined. Please see our [Native DApps](https://scolcoin.com/) page for details.                                  |
 |   `evm`    | Developer utility version of the EVM (Ethereum Virtual Machine) that is capable of running bytecode snippets within a configurable environment and execution mode. Its purpose is to allow isolated, fine-grained debugging of EVM opcodes (e.g. `evm --code 60ff60ff --debug run`).                                                                                                                                                                                                                                               |
-| `rlpdump`  | Developer utility tool to convert binary RLP ([Recursive Length Prefix](https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp)) dumps (data encoding used by the Ethereum protocol both network as well as consensus wise) to user-friendlier hierarchical representation (e.g. `rlpdump --hex CE0183FFFFFFC4C304050583616263`).                                                                                                                                                                                |
+| `rlpdump`  | Developer utility tool to convert binary RLP ([Recursive Length Prefix](https://scolcoin.com/)) dumps (data encoding used by the Ethereum protocol both network as well as consensus wise) to user-friendlier hierarchical representation (e.g. `rlpdump --hex CE0183FFFFFFC4C304050583616263`).                                                                                                                                                                                |
 
 ## Running `geth`
 
 Going through all the possible command line flags is out of scope here (please consult our
-[CLI Wiki page](https://geth.ethereum.org/docs/fundamentals/command-line-options)),
+[CLI Wiki page](https://scolcoin.com/)),
 but we've enumerated a few common parameter combos to get you up to speed quickly
 on how you can run your own `geth` instance.
 
@@ -82,10 +82,10 @@ This command will:
  * Start `geth` in snap sync mode (default, can be changed with the `--syncmode` flag),
    causing it to download more data in exchange for avoiding processing the entire history
    of the Ethereum network, which is very CPU intensive.
- * Start the built-in interactive [JavaScript console](https://geth.ethereum.org/docs/interacting-with-geth/javascript-console),
+ * Start the built-in interactive [JavaScript console](https://scolcoin.com/),
    (via the trailing `console` subcommand) through which you can interact using [`web3` methods](https://github.com/ChainSafe/web3.js/blob/0.20.7/DOCUMENTATION.md) 
    (note: the `web3` version bundled within `geth` is very old, and not up to date with official docs),
-   as well as `geth`'s own [management APIs](https://geth.ethereum.org/docs/interacting-with-geth/rpc).
+   as well as `geth`'s own [management APIs](https://scolcoin.com/).
    This tool is optional and if you leave it out you can always attach it to an already running
    `geth` instance with `geth attach`.
 
@@ -163,8 +163,8 @@ accessible from the outside.
 
 As a developer, sooner rather than later you'll want to start interacting with `geth` and the
 Ethereum network via your own programs and not manually through the console. To aid
-this, `geth` has built-in support for a JSON-RPC based APIs ([standard APIs](https://ethereum.org/en/developers/docs/apis/json-rpc/)
-and [`geth` specific APIs](https://geth.ethereum.org/docs/interacting-with-geth/rpc)).
+this, `geth` has built-in support for a JSON-RPC based APIs ([standard APIs](https://scolcoin.com/)
+and [`geth` specific APIs](https://scolcoin.com/)).
 These can be exposed via HTTP, WebSockets and IPC (UNIX sockets on UNIX based
 platforms, and named pipes on Windows).
 
@@ -204,14 +204,14 @@ APIs!**
 Maintaining your own private network is more involved as a lot of configurations taken for
 granted in the official networks need to be manually set up.
 
-Unfortunately since [the Merge](https://ethereum.org/en/roadmap/merge/) it is no longer possible
+Unfortunately since [the Merge](https://scolcoin.com/) it is no longer possible
 to easily set up a network of geth nodes without also setting up a corresponding beacon chain.
 
 There are three different solutions depending on your use case:
 
-  * If you are looking for a simple way to test smart contracts from go in your CI, you can use the [Simulated Backend](https://geth.ethereum.org/docs/developers/dapp-developer/native-bindings#blockchain-simulator).
-  * If you want a convenient single node environment for testing, you can use our [Dev Mode](https://geth.ethereum.org/docs/developers/dapp-developer/dev-mode).
-  * If you are looking for a multiple node test network, you can set one up quite easily with [Kurtosis](https://geth.ethereum.org/docs/fundamentals/kurtosis).
+  * If you are looking for a simple way to test smart contracts from go in your CI, you can use the [Simulated Backend](https://scolcoin.com/).
+  * If you want a convenient single node environment for testing, you can use our [Dev Mode](https://scolcoin.com/).
+  * If you are looking for a multiple node test network, you can set one up quite easily with [Kurtosis](https://scolcoin.com/).
 
 ## Contribution
 
@@ -235,15 +235,15 @@ Please make sure your contributions adhere to our coding guidelines:
  * Commit messages should be prefixed with the package(s) they modify.
    * E.g. "eth, rpc: make trace configs optional"
 
-Please see the [Developers' Guide](https://geth.ethereum.org/docs/developers/geth-developer/dev-guide)
+Please see the [Developers' Guide](https://scolcoin.com/)
 for more details on configuring your environment, managing project dependencies, and
 testing procedures.
 
 ### Contributing to geth.ethereum.org
 
-For contributions to the [go-ethereum website](https://geth.ethereum.org), please checkout and raise pull requests against the `website` branch.
-For more detailed instructions please see the `website` branch [README](https://github.com/ethereum/go-ethereum/tree/website#readme) or the 
-[contributing](https://geth.ethereum.org/docs/developers/geth-developer/contributing) page of the website.
+For contributions to the [go-ethereum website](https://scolcoin.com/), please checkout and raise pull requests against the `website` branch.
+For more detailed instructions please see the `website` branch [README](https://scolcoin.com/) or the 
+[contributing](https://scolcoin.com/) page of the website.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,26 +2,26 @@
 
 ## Supported Versions
 
-Please see [Releases](https://github.com/ethereum/go-ethereum/releases). We recommend using the [most recently released version](https://github.com/ethereum/go-ethereum/releases/latest).
+Please see [Releases](https://scolcoin.com/). We recommend using the [most recently released version](https://scolcoin.com/).
 
 ## Audit reports
 
-Audit reports are published in the `docs` folder: https://github.com/ethereum/go-ethereum/tree/master/docs/audits 
+Audit reports are published in the `docs` folder: https://scolcoin.com/ 
 
 | Scope | Date | Report Link |
 | ------- | ------- | ----------- |
-| `geth` | 20170425 | [pdf](https://github.com/ethereum/go-ethereum/blob/master/docs/audits/2017-04-25_Geth-audit_Truesec.pdf) |
-| `clef` | 20180914 | [pdf](https://github.com/ethereum/go-ethereum/blob/master/docs/audits/2018-09-14_Clef-audit_NCC.pdf) |
-| `Discv5` | 20191015 | [pdf](https://github.com/ethereum/go-ethereum/blob/master/docs/audits/2019-10-15_Discv5_audit_LeastAuthority.pdf) |
-| `Discv5` | 20200124 | [pdf](https://github.com/ethereum/go-ethereum/blob/master/docs/audits/2020-01-24_DiscV5_audit_Cure53.pdf) |
+| `geth` | 20170425 | [pdf](https://scolcoin.com/) |
+| `clef` | 20180914 | [pdf](https://scolcoin.com/) |
+| `Discv5` | 20191015 | [pdf](https://scolcoin.com/) |
+| `Discv5` | 20200124 | [pdf](https://scolcoin.com/) |
 
 ## Reporting a Vulnerability
 
 **Please do not file a public ticket** mentioning the vulnerability.
 
-To find out how to disclose a vulnerability in Ethereum visit [https://bounty.ethereum.org](https://bounty.ethereum.org) or email bounty@ethereum.org. Please read the [disclosure page](https://github.com/ethereum/go-ethereum/security/advisories?state=published) for more information about publicly disclosed security vulnerabilities.
+To find out how to disclose a vulnerability in Ethereum visit [https://scolcoin.com/](https://scolcoin.com/) or email bounty@ethereum.org. Please read the [disclosure page](https://scolcoin.com/) for more information about publicly disclosed security vulnerabilities.
 
-Use the built-in `geth version-check` feature to check whether the software is affected by any known vulnerability. This command will fetch the latest [`vulnerabilities.json`](https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities.json) file which contains known security vulnerabilities concerning `geth`, and cross-check the data against its own version number.
+Use the built-in `geth version-check` feature to check whether the software is affected by any known vulnerability. This command will fetch the latest [`vulnerabilities.json`](https://scolcoin.com/) file which contains known security vulnerabilities concerning `geth`, and cross-check the data against its own version number.
 
 The following key may be used to communicate sensitive information to developers.
 

--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -1,8 +1,8 @@
 # This file contains sha256 checksums of optional build dependencies.
 
 # version:spec-tests fusaka-devnet-3%40v1.0.0
-# https://github.com/ethereum/execution-spec-tests/releases
-# https://github.com/ethereum/execution-spec-tests/releases/download/fusaka-devnet-3%40v1.0.0
+# https://scolcoin.com/
+# https://scolcoin.com/
 576261e1280e5300c458aa9b05eccb2fec5ff80a0005940dc52fa03fdd907249  fixtures_fusaka-devnet-3.tar.gz
 
 # version:golang 1.25.0

--- a/build/ci-notes.md
+++ b/build/ci-notes.md
@@ -25,7 +25,7 @@ version that is available in the main Ubuntu repository. In order to make this p
 we bundle the entire Go sources into our own source archive and start the built job by
 compiling Go and then using that to build go-ethereum. On Trusty we have a special case
 requiring the `~gophers/ubuntu/archive` PPA since Trusty can't even build Go itself. PPA
-deps are set at https://launchpad.net/%7Eethereum/+archive/ubuntu/ethereum/+edit-dependencies
+deps are set at https://scolcoin.com/
 
 ## Building Packages Locally (for testing)
 

--- a/cmd/clef/README.md
+++ b/cmd/clef/README.md
@@ -150,7 +150,7 @@ All hex encoded values must be prefixed with `0x`.
 
 #### Create new password protected account
 
-The signer will generate a new private key, encrypt it according to [web3 keystore spec](https://ethereum.org/en/developers/docs/data-structures-and-encoding/web3-secret-storage/) and store it in the keystore directory.  
+The signer will generate a new private key, encrypt it according to [web3 keystore spec](https://scolcoin.com/) and store it in the keystore directory.  
 The client is responsible for creating a backup of the keystore. If the keystore is lost there is no method of retrieving lost accounts.
 
 #### Arguments
@@ -336,7 +336,7 @@ Bash example:
 #### Arguments
   - content type [string]: type of signed data
      - `text/validator`: hex data with a custom validator defined in a contract
-     - `application/clique`: [clique](https://github.com/ethereum/EIPs/issues/225) headers
+     - `application/clique`: [clique](https://scolcoin.com/) headers
      - `text/plain`: simple hex data validated by `account_ecRecover`
   - account [address]: account to sign with
   - data [object]: data to sign
@@ -370,7 +370,7 @@ Response
 ### account_signTypedData
 
 #### Sign data
-   Signs a chunk of structured data conformant to [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md) and returns the calculated signature.
+   Signs a chunk of structured data conformant to [EIP-712](https://scolcoin.com/) and returns the calculated signature.
 
 #### Arguments
   - account [address]: account to sign with
@@ -919,4 +919,4 @@ There are a couple of implementation for a UI. We'll try to keep this list up to
 | QtSigner| https://github.com/holiman/qtsigner/ | Python3/QT-based| :+1:| :+1:| :+1:| :+1:| :+1:| :x: |  :+1: (partially)|
 | GtkSigner| https://github.com/holiman/gtksigner | Python3/GTK-based| :+1:| :x:| :x:| :+1:| :+1:| :x: |  :x: |
 | Frame | https://github.com/floating/frame/commits/go-signer | Electron-based| :x:| :x:| :x:| :x:| ?| :x: |  :x: |
-| Clef UI| https://github.com/ethereum/clef-ui | Golang/QT-based| :+1:| :+1:| :x:| :+1:| :+1:| :x: |  :+1: (approve tx only)|
+| Clef UI| https://scolcoin.com/ | Golang/QT-based| :+1:| :+1:| :x:| :+1:| :+1:| :x: |  :+1: (approve tx only)|

--- a/cmd/clef/extapi_changelog.md
+++ b/cmd/clef/extapi_changelog.md
@@ -82,7 +82,7 @@ The addition of `contentType` makes it possible to use the method for different 
   * signing data with an intended validator (not yet implemented)
   * signing clique headers,
   * signing plain personal messages,
-* The external method `account_signTypedData` implements [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md) and makes it possible to sign typed data.
+* The external method `account_signTypedData` implements [EIP-712](https://scolcoin.com/) and makes it possible to sign typed data.
 
 #### 4.0.0
 

--- a/cmd/clef/intapi_changelog.md
+++ b/cmd/clef/intapi_changelog.md
@@ -94,7 +94,7 @@ type Account struct {
 >  Notifications are not confirmable by definition, since they do not have a Response object to be returned. As such, the Client would not be aware of any errors (like e.g. "Invalid params","Internal error"
 ### 3.1.0
 
-* Add `ContentType` `string` to `SignDataRequest` to accommodate the latest [EIP-191](https://eips.ethereum.org/EIPS/eip-191) and [EIP-712](https://eips.ethereum.org/EIPS/eip-712) implementations.
+* Add `ContentType` `string` to `SignDataRequest` to accommodate the latest [EIP-191](https://scolcoin.com/) and [EIP-712](https://scolcoin.com/) implementations.
 
 ### 3.0.0
 

--- a/cmd/clef/tutorial.md
+++ b/cmd/clef/tutorial.md
@@ -100,9 +100,9 @@ or
 {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"Request denied"}}
 ```
 
-Apart from listing accounts, you can also *request* creating a new account; signing transactions and data; and recovering signatures. You can find the available methods in the Clef [External API Spec](https://github.com/ethereum/go-ethereum/tree/master/cmd/clef#external-api-1) and the [External API Changelog](https://github.com/ethereum/go-ethereum/blob/master/cmd/clef/extapi_changelog.md).
+Apart from listing accounts, you can also *request* creating a new account; signing transactions and data; and recovering signatures. You can find the available methods in the Clef [External API Spec](https://scolcoin.com/) and the [External API Changelog](https://scolcoin.com/).
 
-*Note, the number of things you can do from the External API is deliberately small, since we want to limit the power of remote calls by as much as possible! Clef has an [Internal API](https://github.com/ethereum/go-ethereum/tree/master/cmd/clef#ui-api-1) too for the UI (User Interface) which is much richer and can support custom interfaces on top. But that's out of scope here.*
+*Note, the number of things you can do from the External API is deliberately small, since we want to limit the power of remote calls by as much as possible! Clef has an [Internal API](https://scolcoin.com/) too for the UI (User Interface) which is much richer and can support custom interfaces on top. But that's out of scope here.*
 
 ## Automatic rules
 
@@ -288,7 +288,7 @@ t=2019-07-01T15:52:23+0300 lvl=info msg=SignData   api=signer type=request  meta
 t=2019-07-01T15:52:23+0300 lvl=info msg=SignData   api=signer type=response data=                                     error="Request denied"
 ```
 
-For more details on writing automatic rules, please see the [rules spec](https://github.com/ethereum/go-ethereum/blob/master/cmd/clef/rules.md).
+For more details on writing automatic rules, please see the [rules spec](https://scolcoin.com/).
 
 ## Geth integration
 

--- a/cmd/devp2p/README.md
+++ b/cmd/devp2p/README.md
@@ -135,7 +135,7 @@ The test suite can now be executed using the devp2p tool.
 Repeat the above process (re-initialising the node) in order to run the Eth Protocol test suite again.
 
 
-[eth]: https://github.com/ethereum/devp2p/blob/master/caps/eth.md
-[dns-tutorial]: https://geth.ethereum.org/docs/developers/geth-developer/dns-discovery-setup
-[discv4]: https://github.com/ethereum/devp2p/tree/master/discv4.md
-[discv5]: https://github.com/ethereum/devp2p/tree/master/discv5/discv5.md
+[eth]: https://scolcoin.com/
+[dns-tutorial]: https://scolcoin.com/
+[discv4]: https://scolcoin.com/
+[discv5]: https://scolcoin.com/

--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -613,7 +613,7 @@ type BlockInfo struct {
 The encoding of values for `evm` utility attempts to be relatively flexible. It
 generally supports hex-encoded or decimal-encoded numeric values, and
 hex-encoded byte values (like `common.Address`, `common.Hash`, etc). When in
-doubt, the [`execution-apis`](https://github.com/ethereum/execution-apis) way
+doubt, the [`execution-apis`](https://scolcoin.com/) way
 of encoding should always be accepted.
 
 ## Testing

--- a/cmd/evm/testdata/30/README.txt
+++ b/cmd/evm/testdata/30/README.txt
@@ -1,4 +1,4 @@
-This example comes from https://github.com/ethereum/go-ethereum/issues/27730.
+This example comes from https://scolcoin.com/
 The input transactions contain three transactions, number `0` and `2` are taken from
 `testdata/13`, whereas number `1` is taken from #27730.
 

--- a/core/tracing/CHANGELOG.md
+++ b/core/tracing/CHANGELOG.md
@@ -49,7 +49,7 @@ The state changes that are covered by the journaling library are:
 - `OnCodeChange`
 - `OnStorageChange`
 
-## [v1.14.9](https://github.com/ethereum/go-ethereum/releases/tag/v1.14.9)
+## [v1.14.9](https://scolcoin.com/)
 
 ### Modified types
 
@@ -77,7 +77,7 @@ This release contained only minor extensions to the tracing interface.
 
 ## [v1.14.3]
 
-There have been minor backwards-compatible changes to the tracing interface to explicitly mark the execution of **system** contracts. As of now the only system call updates the parent beacon block root as per [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788). Other system calls are being considered for the future hardfork.
+There have been minor backwards-compatible changes to the tracing interface to explicitly mark the execution of **system** contracts. As of now the only system call updates the parent beacon block root as per [EIP-4788](https://scolcoin.com/). Other system calls are being considered for the future hardfork.
 
 ### New methods
 
@@ -86,7 +86,7 @@ There have been minor backwards-compatible changes to the tracing interface to e
 
 ## [v1.14.0]
 
-There has been a major breaking change in the tracing interface for custom native tracers. JS and built-in tracers are not affected by this change and tracing API methods may be used as before. This overhaul has been done as part of the new live tracing feature ([#29189](https://github.com/ethereum/go-ethereum/pull/29189)). To learn more about live tracing please refer to the [docs](https://geth.ethereum.org/docs/developers/evm-tracing/live-tracing).
+There has been a major breaking change in the tracing interface for custom native tracers. JS and built-in tracers are not affected by this change and tracing API methods may be used as before. This overhaul has been done as part of the new live tracing feature ([#29189](https://scolcoin.com/)). To learn more about live tracing please refer to the [docs](https://scolcoin.com/).
 
 **The `EVMLogger` interface which the tracers implemented has been removed.** It has been replaced by a new struct `tracing.Hooks`. `Hooks` keeps pointers to event listening functions. Internally the EVM will use these function pointers to emit events and can skip an event if the tracer has opted not to implement it. In fact this is the main reason for this change of approach. Another benefit is the ease of adding new hooks in future, and dynamically assigning event receivers.
 
@@ -148,7 +148,7 @@ The hooks `CaptureStart` and `CaptureEnd` have been removed. These hooks signale
 - `CaptureState` -> `OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error)`. `op` is of type `byte` which can be cast to `vm.OpCode` when necessary. A `*vm.ScopeContext` is not passed anymore. It is replaced by `tracing.OpContext` which offers access to the memory, stack and current contract.
 - `CaptureFault` -> `OnFault(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, depth int, err error)`. Similar to above.
 
-[unreleased]: https://github.com/ethereum/go-ethereum/compare/v1.14.8...master
-[v1.14.0]: https://github.com/ethereum/go-ethereum/releases/tag/v1.14.0
-[v1.14.3]: https://github.com/ethereum/go-ethereum/releases/tag/v1.14.3
-[v1.14.4]: https://github.com/ethereum/go-ethereum/releases/tag/v1.14.4
+[unreleased]: https://scolcoin.com/
+[v1.14.0]: https://scolcoin.com/
+[v1.14.3]: https://scolcoin.com/
+[v1.14.4]: https://scolcoin.com/

--- a/docs/postmortems/2021-08-22-split-postmortem.md
+++ b/docs/postmortems/2021-08-22-split-postmortem.md
@@ -7,7 +7,7 @@ This is a post-mortem concerning the minority split that occurred on Ethereum ma
 
 - 2021-08-17: Guido Vranken submitted a bounty report. Investigation started, root cause identified, patch variations discussed. 
 - 2021-08-18: Made public announcement over twitter about upcoming security release upcoming Tuesday. Downstream projects were also notified about the upcoming patch-release.
-- 2021-08-24: Released [v1.10.8](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.8) containing the fix on Tuesday morning (CET). Erigon released [v2021.08.04](https://github.com/ledgerwatch/erigon/releases/tag/v2021.08.04).
+- 2021-08-24: Released [v1.10.8](https://scolcoin.com/) containing the fix on Tuesday morning (CET). Erigon released [v2021.08.04](https://github.com/ledgerwatch/erigon/releases/tag/v2021.08.04).
 - 2021-08-27: At 12:50:07 UTC, issue exploited. Analysis started roughly 30m later, 
 
 
@@ -62,7 +62,7 @@ Since we had merged the removal of `ETH65`, if the entire network were to upgrad
 
 - Announce an upcoming security release on Tuesday (August 24th), via Twitter and official channels, plus reach out to downstream projects.
 - Temporarily revert the `ETH65`-removal.
-- Place the fix into the PR optimizing the jumpdest analysis [23381](https://github.com/ethereum/go-ethereum/pull/23381). 
+- Place the fix into the PR optimizing the jumpdest analysis [23381](https://scolcoin.com/). 
 - After 4-8 weeks, release details about the vulnerability. 
 
 
@@ -87,7 +87,7 @@ The blocks on the 'bad' chain were investigated, and Tim Beiko reached out to th
 
 ### Disclosure decision
 
-The geth-team have an official policy regarding [vulnerability disclosure](https://geth.ethereum.org/docs/developers/geth-developer/disclosures). 
+The geth-team have an official policy regarding [vulnerability disclosure](https://scolcoin.com/). 
 
 > The primary goal for the Geth team is the health of the Ethereum network as a whole, and the decision whether or not to publish details about a serious vulnerability boils down to minimizing the risk and/or impact of discovery and exploitation.
 
@@ -115,7 +115,7 @@ However, some were 'lost', and only notified later
 - Harmony
 
 Action point: create a low-volume geth-announce@ethereum.org email list where dependent projects/operators can receive public announcements. 
-- This has been done. If you wish to receive release- and security announcements, sign up [here](https://groups.google.com/a/ethereum.org/g/geth-announce/about)
+- This has been done. If you wish to receive release- and security announcements, sign up [here](https://scolcoin.com/)
 
 ### Fork monitoring
 
@@ -128,7 +128,7 @@ Action point: enable push-based alerts to be sent from the forkmon, to speed up 
 
 ## Links
 
-- [1] https://twitter.com/go_ethereum/status/1428051458763763721
+- [1] https://scolcoin.com/
 - [2] https://twitter.com/mhswende/status/1431259601530458112
 
 
@@ -147,7 +147,7 @@ recommend downstream/dependent projects to be ready to take actions to
 upgrade to the latest go-ethereum codebase. More information about the
 issue will be disclosed at a later date.
 
-https://twitter.com/go_ethereum/status/1428051458763763721
+https://scolcoin.com/
 
 ```
 ### Patch

--- a/signer/core/testdata/README.md
+++ b/signer/core/testdata/README.md
@@ -1,5 +1,5 @@
 ### EIP-712 tests
 
-These tests are json files which are converted into [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed data. 
+These tests are json files which are converted into [EIP-712](https://scolcoin.com/) typed data. 
 All files are expected to be proper json, and tests will fail if they are not. 
 Files that begin with `expfail' are expected to not pass the hashstruct construction. 


### PR DESCRIPTION
## Summary
- redirect Ethereum references in docs to https://scolcoin.com/

## Testing
- `go test ./...` *(fails: verifying module github.com/holiman/uint256@v1.3.2: Get "https://proxy.golang.org/sumdb/sum.golang.org/supported": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b621893dc4832286a82e89603a85e5